### PR TITLE
Validation of node version when using the CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -15,6 +15,12 @@
 
 const cwd = process.cwd();
 require('app-module-path').addPath(cwd);
+const validateNode = require('validate-node-version')('>=7.6.x');
+
+if (!validateNode.satisfies) {
+  console.error(validateNode.message);
+  process.exit(1);
+}
 
 const argv = require('yargs')
   .version()

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "path-to-regexp": "^2.1.0",
     "raw-body": "^2.3.2",
     "upath": "^1.0.2",
+    "validate-node-version": "^1.1.1",
     "yargs": "^11.0.0"
   },
   "bin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2147,6 +2147,10 @@ safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+semver@^5.0.1:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
 semver@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
@@ -2585,6 +2589,12 @@ util@0.10.3, util@^0.10.3:
 uuid@^3.0.0, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
+validate-node-version@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/validate-node-version/-/validate-node-version-1.1.1.tgz#ebfcdb99ab5826c01c3ddcae2ec448f31b5aab14"
+  dependencies:
+    semver "^5.0.1"
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
Warn developers when they're using the CLI that their Node version is not correct.

For example:
```
$ huncwot new some-new-app
Expected node >=7.6.0, but found v6.11.3
```

(Error messaging can be tweaked for `huncwot`'s specific use case, but this is a good start.)